### PR TITLE
chore(internal): add dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+version: 2
+updates:
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: weekly
+    time: "11:00"
+  open-pull-requests-limit: 10
+  versioning-strategy: increase-if-necessary
+  groups:
+    patch-deps-updates-main:
+      update-types:
+        - "patch"
+    minor-deps-updates-main:
+      update-types:
+        - "minor"
+    major-deps-updates-main:
+      update-types:
+        - "major"
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+    time: "11:00"
+  open-pull-requests-limit: 10
+  groups:
+    patch-deps-updates:
+      update-types:
+        - "patch"
+    minor-deps-updates:
+      update-types:
+        - "minor"
+    major-deps-updates:
+      update-types:
+        - "major"


### PR DESCRIPTION
Adding a Dependabot configuration that will raise grouped dependency updates once a week.